### PR TITLE
Fix wago project ID

### DIFF
--- a/AdiBags_Shadowlands.toc
+++ b/AdiBags_Shadowlands.toc
@@ -6,6 +6,6 @@
 ## Dependencies: AdiBags
 ## X-Curse-Project-ID: 423029
 ## X-WoWI-ID: 25821
-## X-Wago-ID: ZQ6a976W
+## X-Wago-ID: q96d9OKO
 
 AdiBags_Shadowlands.lua


### PR DESCRIPTION
This fixes the Wago Project ID which currently is set to the ID of https://addons.wago.io/addons/a-deal-with-de-loa-bwonsamdi